### PR TITLE
Feat: Get party by id, Refactor: Check user is valid when creating party (#4)

### DIFF
--- a/src/party/party.service.ts
+++ b/src/party/party.service.ts
@@ -14,7 +14,11 @@ export class PartyService {
     private partyRepository: Repository<EatParty>,
   ) {}
 
-  async create(host: User, data: CreatePartyDto): Promise<EatParty | null> {
+  async findOne(id: number): Promise<EatParty | undefined> {
+    return await this.partyRepository.findOne({ id });
+  }
+
+  async create(host: User, data: CreatePartyDto): Promise<EatParty> {
     const party: EatParty = new EatParty();
     party.title = data.title;
     party.description = data.description;


### PR DESCRIPTION
- 파라미터로 들어온 `id` 값에 따라 "같이 먹을래?"의 정보를 가져온다.
- 만약 `id`에 맞는 "같이 먹을래?"가 존재하지 않을 경우, 404(Not Found)를 클라이언트에게 보낸다.

<br/>

- "같이 먹을래?"를 만들 때 들어온 유저의 아이디가 데이터베이스에 존재하지 않을 경우, 403(Forbidden)을 클라이언트에게 보낸다.