### PR TITLE
Feat: Get party near 500m from user (#3)

### DIFF
--- a/src/common/parse_float.pipe.ts
+++ b/src/common/parse_float.pipe.ts
@@ -1,0 +1,23 @@
+import {
+  ArgumentMetadata,
+  HttpStatus,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
+import { HttpErrorByCode } from '@nestjs/common/utils/http-error-by-code.util';
+
+@Injectable()
+export class ParseFloatPipe implements PipeTransform<string> {
+  async transform(value: string, metadata: ArgumentMetadata): Promise<number> {
+    const isNumeric =
+      ['string', 'number'].includes(typeof value) &&
+      !isNaN(parseFloat(value)) &&
+      isFinite(value as any);
+    if (!isNumeric) {
+      throw new HttpErrorByCode[HttpStatus.BAD_REQUEST](
+        'Validation failed (numeric string is expected)',
+      );
+    }
+    return parseFloat(value);
+  }
+}

--- a/src/common/parse_float.pipe.ts
+++ b/src/common/parse_float.pipe.ts
@@ -1,10 +1,10 @@
 import {
   ArgumentMetadata,
+  HttpException,
   HttpStatus,
   Injectable,
   PipeTransform,
 } from '@nestjs/common';
-import { HttpErrorByCode } from '@nestjs/common/utils/http-error-by-code.util';
 
 @Injectable()
 export class ParseFloatPipe implements PipeTransform<string> {
@@ -14,8 +14,9 @@ export class ParseFloatPipe implements PipeTransform<string> {
       !isNaN(parseFloat(value)) &&
       isFinite(value as any);
     if (!isNumeric) {
-      throw new HttpErrorByCode[HttpStatus.BAD_REQUEST](
+      throw new HttpException(
         'Validation failed (numeric string is expected)',
+        HttpStatus.BAD_REQUEST,
       );
     }
     return parseFloat(value);

--- a/src/common/response.ts
+++ b/src/common/response.ts
@@ -12,14 +12,20 @@ class Resp {
     500: 'Internal Server Error',
   };
 
-  static ok(data: any) {
+  static ok(data: any, raw?: boolean) {
+    if (raw) return data;
     return { code: 200, data: data };
   }
 
-  static error(code: number): ErrorType {
+  static error(code: number, message?: string): ErrorType {
+    let resultMessage: string = this.ERROR_MESSAGE[code];
+    if (message) {
+      resultMessage = resultMessage.concat(' : ').concat(message);
+    }
+
     return {
       code,
-      message: this.ERROR_MESSAGE[code],
+      message: resultMessage,
       timestamp: new Date().toISOString(),
     };
   }

--- a/src/filter/http_exception.filter.ts
+++ b/src/filter/http_exception.filter.ts
@@ -5,12 +5,15 @@ import {
   HttpException,
 } from '@nestjs/common';
 import { Response } from 'express';
+import { Resp } from 'src/common/response';
 
 @Catch(HttpException)
 export class HttpExceptionFilter implements ExceptionFilter {
   catch(exception: HttpException, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
-    response.status(exception.getStatus()).json(exception.getResponse());
+    response
+      .status(exception.getStatus())
+      .json(Resp.error(exception.getStatus(), String(exception.getResponse())));
   }
 }

--- a/src/middleware/auth/auth.middleware.ts
+++ b/src/middleware/auth/auth.middleware.ts
@@ -1,7 +1,6 @@
 import { HttpException, Injectable, NestMiddleware } from '@nestjs/common';
 import { NextFunction, Request, Response } from 'express';
 import * as admin from 'firebase-admin';
-import { Resp } from 'src/common/response';
 
 @Injectable()
 export class AuthMiddleware implements NestMiddleware {
@@ -16,10 +15,10 @@ export class AuthMiddleware implements NestMiddleware {
           next();
         })
         .catch(() => {
-          throw new HttpException(Resp.error(403), 403);
+          throw new HttpException('Not Valid Id Token', 403);
         });
     } else {
-      throw new HttpException(Resp.error(403), 403);
+      throw new HttpException('Token is required', 403);
     }
   }
 }

--- a/src/middleware/get_user/get_user.middleware.ts
+++ b/src/middleware/get_user/get_user.middleware.ts
@@ -6,7 +6,6 @@ import {
 } from '@nestjs/common';
 import { NextFunction, Request, Response } from 'express';
 import { auth } from 'firebase-admin';
-import { Resp } from 'src/common/response';
 import { UserService } from 'src/user/user.service';
 
 @Injectable()
@@ -17,7 +16,10 @@ export class GetUserMiddleware implements NestMiddleware {
     const token: auth.DecodedIdToken = req['gfUser'];
     this.userService.findOne(token.uid).then((user) => {
       if (!user) {
-        throw new HttpException(Resp.error(400), HttpStatus.BAD_REQUEST);
+        throw new HttpException(
+          "Can't find user by token's uid.",
+          HttpStatus.BAD_REQUEST,
+        );
       }
 
       req['user'] = user;

--- a/src/party/party.controller.ts
+++ b/src/party/party.controller.ts
@@ -29,7 +29,9 @@ export class PartyController {
   async getParties(
     @Query('latitude', ParseFloatPipe) latitude: number,
     @Query('longitude', ParseFloatPipe) longitude: number,
-  ) {}
+  ) {
+    return Resp.ok(await this.partyService.findNear500m(latitude, longitude));
+  }
 
   @Get(':id')
   async getParty(@Param('id', ParseIntPipe) id: number) {

--- a/src/party/party.controller.ts
+++ b/src/party/party.controller.ts
@@ -9,9 +9,11 @@ import {
   ParseIntPipe,
   Post,
   Put,
+  Query,
   Req,
 } from '@nestjs/common';
 import { Request } from 'express';
+import { ParseFloatPipe } from 'src/common/parse_float.pipe';
 import { Resp } from 'src/common/response';
 import { Party } from 'src/party/party.entity';
 import { User } from 'src/user/user.entity';
@@ -22,6 +24,12 @@ import { PartyService } from './party.service';
 @Controller('party')
 export class PartyController {
   constructor(private partyService: PartyService) {}
+
+  @Get()
+  async getParties(
+    @Query('latitude', ParseFloatPipe) latitude: number,
+    @Query('longitude', ParseFloatPipe) longitude: number,
+  ) {}
 
   @Get(':id')
   async getParty(@Param('id', ParseIntPipe) id: number) {

--- a/src/party/party.controller.ts
+++ b/src/party/party.controller.ts
@@ -37,7 +37,10 @@ export class PartyController {
   async getParty(@Param('id', ParseIntPipe) id: number) {
     const party: Party = await this.partyService.findOne(id);
     if (!party) {
-      throw new HttpException(Resp.error(404), HttpStatus.NOT_FOUND);
+      throw new HttpException(
+        "Can' find party by given id",
+        HttpStatus.NOT_FOUND,
+      );
     }
     return Resp.ok(party);
   }

--- a/src/party/party.entity.ts
+++ b/src/party/party.entity.ts
@@ -27,13 +27,13 @@ export class Party {
   @Length(1, 100)
   restuarant: string;
 
-  @Column({ type: 'int' })
+  @Column({ type: 'decimal' })
   @IsNotEmpty()
   @IsNumber()
   @Min(0.0)
   meetLatitude: number;
 
-  @Column({ type: 'int' })
+  @Column({ type: 'decimal' })
   @IsNotEmpty()
   @IsNumber()
   @Min(0.0)

--- a/src/party/party.entity.ts
+++ b/src/party/party.entity.ts
@@ -1,4 +1,12 @@
-import { IsInt, IsNotEmpty, IsNumber, Length, Min } from 'class-validator';
+import {
+  IsInt,
+  IsLatitude,
+  IsLongitude,
+  IsNotEmpty,
+  IsNumber,
+  Length,
+  Min,
+} from 'class-validator';
 import {
   Column,
   Entity,

--- a/src/party/party.service.ts
+++ b/src/party/party.service.ts
@@ -1,7 +1,6 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { validate } from 'class-validator';
-import { Resp } from 'src/common/response';
 import { Party } from 'src/party/party.entity';
 import { User } from 'src/user/user.entity';
 import { DeleteResult, Repository } from 'typeorm';
@@ -69,7 +68,7 @@ export class PartyService {
 
     const errors = await validate(party);
     if (errors.length > 0) {
-      throw new HttpException(Resp.error(400), HttpStatus.BAD_REQUEST);
+      throw new HttpException('Not valid data', HttpStatus.BAD_REQUEST);
     }
 
     const result = this.partyRepository.create(party);
@@ -79,13 +78,16 @@ export class PartyService {
   async edit(user: User, partyId: number, data: EditPartyDto): Promise<Party> {
     let party: Party = await this.partyRepository.findOne(partyId);
     if (party.host.id !== user.id) {
-      throw new HttpException(Resp.error(403), HttpStatus.FORBIDDEN);
+      throw new HttpException(
+        'Party organizer only can edit party content',
+        HttpStatus.FORBIDDEN,
+      );
     }
 
     party = { ...party, ...data };
     const erros = await validate(party);
     if (erros.length > 0) {
-      throw new HttpException(Resp.error(400), HttpStatus.BAD_REQUEST);
+      throw new HttpException('Not valid data', HttpStatus.BAD_REQUEST);
     }
 
     return await this.partyRepository.save(data);
@@ -94,7 +96,10 @@ export class PartyService {
   async delete(user: User, partyId: number): Promise<DeleteResult> {
     const party: Party = await this.partyRepository.findOne(partyId);
     if (party.host.id !== user.id) {
-      throw new HttpException(Resp.error(403), HttpStatus.FORBIDDEN);
+      throw new HttpException(
+        'Party organizer only can delete party',
+        HttpStatus.FORBIDDEN,
+      );
     }
 
     return await this.partyRepository.delete({ id: partyId });

--- a/src/party/party.service.ts
+++ b/src/party/party.service.ts
@@ -19,6 +19,19 @@ export class PartyService {
   }
 
   async findNear500m(latitude: number, longitude: number): Promise<Party[]> {
+    if (!this.validateLatitude(latitude)) {
+      throw new HttpException(
+        `Wrong Latitude Range : ${latitude}, Latitude must in [-90.0, 90.0]`,
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    if (!this.validateLongitude(longitude)) {
+      throw new HttpException(
+        `Wrong Longitude Range : ${longitude}, Longitude must in [-180.0, 180.0]`,
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
     return await this.partyRepository
       .createQueryBuilder()
       .having(
@@ -33,6 +46,14 @@ export class PartyService {
       ) // (`latitude`, `logitude`)와 DB의 (`meetLatitude`, `meetLongitude`)의 거리를 계산하여, 500m 이하인 것만 가져온다.
       .orderBy('distance')
       .getMany();
+  }
+
+  private validateLatitude(latitude: number): boolean {
+    return -90.0 <= latitude && latitude <= 90.0;
+  }
+
+  private validateLongitude(longitude: number): boolean {
+    return -180.0 <= longitude && longitude <= 180.0;
   }
 
   async create(host: User, data: CreatePartyDto): Promise<Party> {

--- a/src/party/party.service.ts
+++ b/src/party/party.service.ts
@@ -18,6 +18,23 @@ export class PartyService {
     return await this.partyRepository.findOne({ id });
   }
 
+  async findNear500m(latitude: number, longitude: number): Promise<Party[]> {
+    return await this.partyRepository
+      .createQueryBuilder()
+      .having(
+        `
+          (
+            (
+              6371*acos(cos(radians(${latitude}))*cos(radians(meetLatitude))*cos(radians(meetLongitude)
+              -radians(${longitude}))+sin(radians(${latitude}))*sin(radians(meetLatitude)))
+            ) * 1000
+          ) <= 500
+        `,
+      ) // (`latitude`, `logitude`)와 DB의 (`meetLatitude`, `meetLongitude`)의 거리를 계산하여, 500m 이하인 것만 가져온다.
+      .orderBy('distance')
+      .getMany();
+  }
+
   async create(host: User, data: CreatePartyDto): Promise<Party> {
     const party: Party = new Party();
     party.title = data.title;


### PR DESCRIPTION
## ParseFloatPipe
쿼리로 들어오는 위도(`latitude`)와 경도(`longitude`)를 실수로 파싱하기 위한 파이프를 구현하였습니다.

- 숫자가 아니거나, 파싱했을 때 `NaN`이 나오거나, 무한인 경우 클라이언트에게 상태 코드 400(BAD_REQUEST)을 보냅니다.

## 예외 처리 변경
예외를 발생시킬 때 쓸데없이 코드를 두 번 넣어야했고, 메세지를 넣지 못했습니다.
ex) `throw new HttpException(Resp.error(403), 403);`

이를 수정하여, 클라이언트에게 보내는 형태는 그대로 유지되지만 메세지를 담을 수 있게 바꾸었습니다. 이제 아래와 같이 예외를 발생시키면 됩니다.
```typescript
throw new HttpException(message, code);
```

## 근처 500m 내에 있는 "같이 먹을래?"의 목록을 가져오기
'/party?latitude=<위도>&longitude=<경도>', GET

들어온 위도와 경도에 따라 주위 500m의 "같이 먹을래?"의 객체의 리스트를 클라이언트에게 보냅니다.

- 만약 들어온 위도와 경도가 실수 값이 아닌 경우 클라이언트에게 상태 코드 400(BAD_REQUEST)을 보냅니다.
- 만약 들어온 위도나 경도의 범위가 유효하지 않을 경우 클라이언트에게 상태 코드 400(BAD_REQUEST)을 보냅니다.