### PR TITLE
Feat: Gather complete (#10)

### DIFF
--- a/src/party/gather_complete.dto.ts
+++ b/src/party/gather_complete.dto.ts
@@ -1,0 +1,8 @@
+import { IsInt, IsNotEmpty, Min } from 'class-validator';
+
+export class GatherCompleteDto {
+  @IsNotEmpty()
+  @IsInt()
+  @Min(0)
+  partyId: number;
+}

--- a/src/party/gather_complete.dto.ts
+++ b/src/party/gather_complete.dto.ts
@@ -1,8 +1,0 @@
-import { IsInt, IsNotEmpty, Min } from 'class-validator';
-
-export class GatherCompleteDto {
-  @IsNotEmpty()
-  @IsInt()
-  @Min(0)
-  partyId: number;
-}

--- a/src/party/party.controller.ts
+++ b/src/party/party.controller.ts
@@ -3,8 +3,6 @@ import {
   Controller,
   Delete,
   Get,
-  HttpException,
-  HttpStatus,
   Param,
   ParseIntPipe,
   Post,
@@ -36,12 +34,6 @@ export class PartyController {
   @Get(':id')
   async getParty(@Param('id', ParseIntPipe) id: number) {
     const party: Party = await this.partyService.findOne(id);
-    if (!party) {
-      throw new HttpException(
-        "Can' find party by given id",
-        HttpStatus.NOT_FOUND,
-      );
-    }
     return Resp.ok(party);
   }
 

--- a/src/party/party.dto.ts
+++ b/src/party/party.dto.ts
@@ -1,3 +1,5 @@
+import { Party } from './party.entity';
+
 export class CreatePartyDto {
   title: string;
   description?: string;
@@ -7,4 +9,4 @@ export class CreatePartyDto {
   goalPrice: number;
 }
 
-export type EditPartyDto = Partial<CreatePartyDto>;
+export type EditPartyDto = Partial<Omit<Party, 'id' | 'host' | 'participant'>>;

--- a/src/party/party.entity.ts
+++ b/src/party/party.entity.ts
@@ -1,12 +1,4 @@
-import {
-  IsInt,
-  IsLatitude,
-  IsLongitude,
-  IsNotEmpty,
-  IsNumber,
-  Length,
-  Min,
-} from 'class-validator';
+import { IsInt, IsNotEmpty, IsNumber, Length, Min } from 'class-validator';
 import {
   Column,
   Entity,
@@ -52,6 +44,9 @@ export class Party {
   @IsInt()
   @Min(0)
   goalPrice: number;
+
+  @Column({ type: 'boolean', default: false })
+  isComplete: boolean;
 
   @OneToOne(() => User)
   @JoinColumn()

--- a/src/party/party.service.ts
+++ b/src/party/party.service.ts
@@ -77,6 +77,13 @@ export class PartyService {
 
   async edit(user: User, partyId: number, data: EditPartyDto): Promise<Party> {
     let party: Party = await this.partyRepository.findOne(partyId);
+    if (!party) {
+      throw new HttpException(
+        "Can't find party with given id.",
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
     if (party.host.id !== user.id) {
       throw new HttpException(
         'Party organizer only can edit party content',
@@ -95,6 +102,13 @@ export class PartyService {
 
   async delete(user: User, partyId: number): Promise<DeleteResult> {
     const party: Party = await this.partyRepository.findOne(partyId);
+    if (!party) {
+      throw new HttpException(
+        "Can't find party with given id.",
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
     if (party.host.id !== user.id) {
       throw new HttpException(
         'Party organizer only can delete party',

--- a/src/party/party.service.ts
+++ b/src/party/party.service.ts
@@ -14,7 +14,9 @@ export class PartyService {
   ) {}
 
   async findOne(id: number): Promise<Party | undefined> {
-    return await this.partyRepository.findOne({ id });
+    const party: Party = await this.partyRepository.findOne({ id });
+    if (!party) this.partyNotFound();
+    return party;
   }
 
   async findNear500m(latitude: number, longitude: number): Promise<Party[]> {
@@ -77,19 +79,9 @@ export class PartyService {
 
   async edit(user: User, partyId: number, data: EditPartyDto): Promise<Party> {
     let party: Party = await this.partyRepository.findOne(partyId);
-    if (!party) {
-      throw new HttpException(
-        "Can't find party with given id.",
-        HttpStatus.FORBIDDEN,
-      );
-    }
 
-    if (party.host.id !== user.id) {
-      throw new HttpException(
-        'Party organizer only can edit party content',
-        HttpStatus.FORBIDDEN,
-      );
-    }
+    if (!party) this.partyNotFound();
+    if (party.host.id !== user.id) this.notOrganizer();
 
     party = { ...party, ...data };
     const erros = await validate(party);
@@ -102,20 +94,24 @@ export class PartyService {
 
   async delete(user: User, partyId: number): Promise<DeleteResult> {
     const party: Party = await this.partyRepository.findOne(partyId);
-    if (!party) {
-      throw new HttpException(
-        "Can't find party with given id.",
-        HttpStatus.FORBIDDEN,
-      );
-    }
 
-    if (party.host.id !== user.id) {
-      throw new HttpException(
-        'Party organizer only can delete party',
-        HttpStatus.FORBIDDEN,
-      );
-    }
+    if (!party) this.partyNotFound();
+    if (party.host.id !== user.id) this.notOrganizer();
 
     return await this.partyRepository.delete({ id: partyId });
+  }
+
+  private partyNotFound(): void {
+    throw new HttpException(
+      "Can't find party by given id.",
+      HttpStatus.NOT_FOUND,
+    );
+  }
+
+  private notOrganizer(): void {
+    throw new HttpException(
+      'Party organizer only can delete party',
+      HttpStatus.FORBIDDEN,
+    );
   }
 }


### PR DESCRIPTION
## "같이 먹을래?" 모집 완료
`/party/complete`로 정의하려 하였으나, 기존에 있는 `edit` 메서드를 사용하면 되므로 삭제하였습니다.
대신, `Party` 엔티티에 `isComplete`라는 열을 추가하였습니다.
위 과정으로 인해 `EditPartyDto`가 변경되어야 할 필요성이 생겼고, `Omit`을 활용하여 유저가 임의로 변경할 수 없는 데이터인 아이디(`id`), 주최자(`host`), 참가자 리스트(`participant`)를 제외한 뒤 `Partial`로 정의하였습니다.

## 예외 발생을 메서드로 묶어, 코드의 중복 제거
"같이 먹을래?"의 아이디를 통해 데이터베이스에서 정보를 가져오는 과정에서 찾을 수 없을 경우, 그리고 주최자만 사용할 수 있는 기능을 주최자가 아닌 사람이 접근 했을 때 각각 예외를 발생시켰는데, 이를 메서드로 묶어서 중복을 제거하고 가독성을 높였습니다.