### PR TITLE
Feat: Cancel organize (#13)

### DIFF
--- a/src/party/party.controller.ts
+++ b/src/party/party.controller.ts
@@ -15,7 +15,6 @@ import { ParseFloatPipe } from 'src/common/parse_float.pipe';
 import { Resp } from 'src/common/response';
 import { Party } from 'src/party/party.entity';
 import { User } from 'src/user/user.entity';
-import { DeleteResult } from 'typeorm';
 import { CreatePartyDto, EditPartyDto } from './party.dto';
 import { PartyService } from './party.service';
 
@@ -61,7 +60,10 @@ export class PartyController {
     @Param('id', ParseIntPipe) id: number,
   ) {
     const user: User = req['user'];
-    const result: DeleteResult = await this.partyService.delete(user, id);
+    const result: Party = await this.partyService.edit(user, id, {
+      removedAt: new Date(),
+      state: 'delete',
+    });
     return Resp.ok(result);
   }
 }

--- a/src/party/party.controller.ts
+++ b/src/party/party.controller.ts
@@ -62,7 +62,7 @@ export class PartyController {
     const user: User = req['user'];
     const result: Party = await this.partyService.edit(user, id, {
       removedAt: new Date(),
-      state: 'delete',
+      state: 'canceled',
     });
     return Resp.ok(result);
   }

--- a/src/party/party.entity.ts
+++ b/src/party/party.entity.ts
@@ -21,7 +21,7 @@ const states = [
   'participating',
   'gather-complete',
   'success',
-  'delete',
+  'canceled',
 ] as const;
 type PartyState = typeof states[number];
 

--- a/src/party/party.entity.ts
+++ b/src/party/party.entity.ts
@@ -1,4 +1,12 @@
-import { IsInt, IsNotEmpty, IsNumber, Length, Min } from 'class-validator';
+import {
+  IsDate,
+  IsIn,
+  IsInt,
+  IsNotEmpty,
+  IsNumber,
+  Length,
+  Min,
+} from 'class-validator';
 import {
   Column,
   Entity,
@@ -8,6 +16,14 @@ import {
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { User } from '../user/user.entity';
+
+const states = [
+  'participating',
+  'gather-complete',
+  'success',
+  'delete',
+] as const;
+type PartyState = typeof states[number];
 
 @Entity({ name: 'Party' })
 export class Party {
@@ -45,8 +61,17 @@ export class Party {
   @Min(0)
   goalPrice: number;
 
-  @Column({ type: 'boolean', default: false })
-  isComplete: boolean;
+  @Column({ type: 'varchar', default: false })
+  @IsIn(states)
+  state: PartyState;
+
+  @Column({ type: 'datetime' })
+  @IsDate()
+  createdAt: Date;
+
+  @Column({ type: 'datetime' })
+  @IsDate()
+  removedAt: Date;
 
   @OneToOne(() => User)
   @JoinColumn()


### PR DESCRIPTION
## "같이 먹을래?" 취소
'/party/:id', DELETE
기존에는 실제로 해당 데이터를 삭제하였지만, 이 경우 삭제된 "같이 먹을래?"에 참여한 사람은 갑자기 사라져버린 형태가 되며, 증거가 남지 않습니다.
따라서 데이터는 그대로 두되, 상태를 바꿈으로써 삭제 처리를 구현하였습니다.

## `Party` 엔티티에 `state` 행 추가
위의 사항 때문에 하나의 엔티티가 상태를 띠게 됩니다. 따라서 이를 나타낼 행이 필요해졌고, 이것이 바로 `state` 행입니다.
`PartyState` 타입이며, 아래의 값을 가질 수 있습니다.
```typescript
'participating', 'gather-complete', 'success', 'canceled'
```