### PR TITLE
Feat: Set party state 'successed' (#14)

### DIFF
--- a/src/party/party.controller.ts
+++ b/src/party/party.controller.ts
@@ -54,18 +54,6 @@ export class PartyController {
     return Resp.ok(result);
   }
 
-  @Put('success/:id')
-  async partySuccess(
-    @Req() req: Request,
-    @Param('id', ParseIntPipe) id: number,
-  ) {
-    const user: User = req['user'];
-    const result: Party = await this.partyService.edit(user, id, {
-      state: 'success',
-    });
-    return Resp.ok(result);
-  }
-
   @Delete(':id')
   async deleteParty(
     @Req() req: Request,

--- a/src/party/party.controller.ts
+++ b/src/party/party.controller.ts
@@ -54,6 +54,18 @@ export class PartyController {
     return Resp.ok(result);
   }
 
+  @Put('success/:id')
+  async partySuccess(
+    @Req() req: Request,
+    @Param('id', ParseIntPipe) id: number,
+  ) {
+    const user: User = req['user'];
+    const result: Party = await this.partyService.edit(user, id, {
+      state: 'success',
+    });
+    return Resp.ok(result);
+  }
+
   @Delete(':id')
   async deleteParty(
     @Req() req: Request,

--- a/src/party/party.service.ts
+++ b/src/party/party.service.ts
@@ -83,9 +83,11 @@ export class PartyService {
     if (!party) this.partyNotFound();
     if (party.host.id !== user.id) this.notOrganizer();
 
+    if (party.state === 'success') this.alreadySuccessed();
+
     party = { ...party, ...data };
-    const erros = await validate(party);
-    if (erros.length > 0) {
+    const errors = await validate(party);
+    if (errors.length > 0) {
       throw new HttpException('Not valid data', HttpStatus.BAD_REQUEST);
     }
 
@@ -112,6 +114,13 @@ export class PartyService {
     throw new HttpException(
       'Party organizer only can delete party',
       HttpStatus.FORBIDDEN,
+    );
+  }
+
+  private alreadySuccessed(): void {
+    throw new HttpException(
+      "The party is already successed. You can't edit.",
+      HttpStatus.BAD_REQUEST,
     );
   }
 }


### PR DESCRIPTION
## "같이 먹을래?" 성공 처리
'/party/:id', PUT
아이디가 `id`인 "같이 먹을래"의 상태를 성공(`successed`)으로 바꾼다.
원래는 `/party/success/:id`를 사용하려 하였으나, 굳이 그럴 필요가 있나 생각하여 다시 `editParty`를 재사용하였다.
한 번 성공 처리된 "같이 먹을래?"는 수정할 수 없다.

만약 성공 처리된 "같이 먹을래?"를 수정할 경우 상태 코드 400을 보낸다.