### PR TITLE
Feat: Functions after complete (#22)

### DIFF
--- a/src/common/user.decorator.ts
+++ b/src/common/user.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const UserDeco = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const req = ctx.switchToHttp().getRequest();
+    return req['user'];
+  },
+);

--- a/src/party/after_complete.guard.ts
+++ b/src/party/after_complete.guard.ts
@@ -1,0 +1,30 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+  Injectable,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { Party } from './party.entity';
+import { PartyService } from './party.service';
+
+@Injectable()
+export class AfterCompleteGuard implements CanActivate {
+  constructor(private readonly partyService: PartyService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req: Request = context.switchToHttp().getRequest();
+    const partyId: number = parseInt(req.params.partyId);
+
+    if (!partyId) {
+      throw new HttpException(
+        'Validation failed (numeric string is expected)',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    const party: Party = await this.partyService.findOne(partyId);
+    return party.state === 'gather-complete';
+  }
+}

--- a/src/party/only_host.guard.ts
+++ b/src/party/only_host.guard.ts
@@ -1,0 +1,40 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+  Injectable,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { User } from 'src/user/user.entity';
+import { Party } from './party.entity';
+import { PartyService } from './party.service';
+
+@Injectable()
+export class OnlyHostGuard implements CanActivate {
+  constructor(private readonly partyService: PartyService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req: Request = context.switchToHttp().getRequest();
+    const partyId: number = parseInt(req.params.partyId);
+
+    if (!partyId) {
+      throw new HttpException(
+        'Validation failed (numeric string is expected)',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    const party: Party = await this.partyService.findOne(partyId);
+    const user: User = req['user'];
+
+    if (party.host.id !== user.id) {
+      throw new HttpException(
+        'Party organizer only can delete party',
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
+    return true;
+  }
+}

--- a/src/party/only_participant.guard.ts
+++ b/src/party/only_participant.guard.ts
@@ -1,0 +1,44 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+  Injectable,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { User } from 'src/user/user.entity';
+import { Party } from './party.entity';
+import { PartyService } from './party.service';
+
+@Injectable()
+export class OnlyParticipantGuard implements CanActivate {
+  constructor(private partyService: PartyService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req: Request = context.switchToHttp().getRequest();
+    const partyId: number = parseInt(req.params.partyId);
+
+    if (!partyId) {
+      throw new HttpException(
+        'Validation failed (numeric string is expected)',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    const party: Party = await this.partyService.findOne(partyId);
+    const user: User = req['user'];
+
+    const isParticipated = party.participate.reduce(
+      (acc, prev) => acc || prev.participant.id === user.id,
+      false,
+    );
+    if (party.host.id !== user.id && !isParticipated) {
+      throw new HttpException(
+        'Party organizer only can delete party',
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
+    return true;
+  }
+}

--- a/src/party/party.controller.ts
+++ b/src/party/party.controller.ts
@@ -19,6 +19,7 @@ import { Party } from 'src/party/party.entity';
 import { User } from 'src/user/user.entity';
 import { AfterCompleteGuard } from './after_complete.guard';
 import { OnlyHostGuard } from './only_host.guard';
+import { OnlyParticipantGuard } from './only_participant.guard';
 import { CreatePartyDto, EditPartyDto } from './party.dto';
 import { MessageType, PartyService } from './party.service';
 
@@ -65,7 +66,7 @@ export class PartyController {
   }
 
   @Put(':partyId/message/:msgType')
-  @UseGuards(AfterCompleteGuard)
+  @UseGuards(AfterCompleteGuard, OnlyParticipantGuard)
   async sendOrderedFoodMessage(
     @UserDeco() user: User,
     @Param('partyId', ParseIntPipe) partyId: number,

--- a/src/party/party.controller.ts
+++ b/src/party/party.controller.ts
@@ -14,12 +14,13 @@ import {
 import { Request } from 'express';
 import { ParseFloatPipe } from 'src/common/parse_float.pipe';
 import { Resp } from 'src/common/response';
+import { UserDeco } from 'src/common/user.decorator';
 import { Party } from 'src/party/party.entity';
 import { User } from 'src/user/user.entity';
 import { AfterCompleteGuard } from './after_complete.guard';
 import { OnlyHostGuard } from './only_host.guard';
 import { CreatePartyDto, EditPartyDto } from './party.dto';
-import { PartyService } from './party.service';
+import { MessageType, PartyService } from './party.service';
 
 @Controller('party')
 export class PartyController {
@@ -61,6 +62,21 @@ export class PartyController {
   async setPartySuccess(@Param('partyId', ParseIntPipe) id: number) {
     const result: Party = await this.partyService.partySuccess(id);
     return Resp.ok(result);
+  }
+
+  @Put(':partyId/message/:msgType')
+  @UseGuards(AfterCompleteGuard)
+  async sendOrderedFoodMessage(
+    @UserDeco() user: User,
+    @Param('partyId', ParseIntPipe) partyId: number,
+    @Param('msgType') msgType: MessageType,
+  ) {
+    const result: number = await this.partyService.sendMessage(
+      user,
+      partyId,
+      msgType,
+    );
+    return Resp.ok({ failCount: result });
   }
 
   @Delete(':partyId')

--- a/src/party/party.controller.ts
+++ b/src/party/party.controller.ts
@@ -67,7 +67,7 @@ export class PartyController {
 
   @Put(':partyId/message/:msgType')
   @UseGuards(AfterCompleteGuard, OnlyParticipantGuard)
-  async sendOrderedFoodMessage(
+  async sendMessage(
     @UserDeco() user: User,
     @Param('partyId', ParseIntPipe) partyId: number,
     @Param('msgType') msgType: MessageType,

--- a/src/party/party.entity.ts
+++ b/src/party/party.entity.ts
@@ -74,6 +74,15 @@ export class Party {
   @IsDate()
   removedAt: Date;
 
+  @Column({ type: 'bool' })
+  usedFirstMessage: boolean;
+
+  @Column({ type: 'bool' })
+  usedSecondMessage: boolean;
+
+  @Column({ type: 'datetime' })
+  otherMessageUsedDate: Date;
+
   @OneToOne(() => User, (user) => user.party)
   @JoinColumn()
   host: User;

--- a/src/party/party.module.ts
+++ b/src/party/party.module.ts
@@ -1,13 +1,15 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Party } from 'src/party/party.entity';
+import { UserModule } from 'src/user/user.module';
+import { AfterCompleteGuard } from './after_complete.guard';
 import { PartyController } from './party.controller';
 import { PartyService } from './party.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Party])],
+  imports: [TypeOrmModule.forFeature([Party]), UserModule],
   controllers: [PartyController],
-  providers: [PartyService],
+  providers: [PartyService, AfterCompleteGuard],
   exports: [PartyService],
 })
 export class PartyModule {}

--- a/src/party/party.service.ts
+++ b/src/party/party.service.ts
@@ -167,11 +167,14 @@ export class PartyService {
     type: MessageType,
   ) {
     const current: Date = new Date();
-    const millisecDiff: number =
-      current.getTime() - party.otherMessageUsedDate.getTime();
 
-    if (millisecDiff < 30 * 1000) {
-      throw new HttpException(`${millisecDiff}`, HttpStatus.BAD_REQUEST);
+    if (party.otherMessageUsedDate) {
+      const millisecDiff: number =
+        current.getTime() - party.otherMessageUsedDate.getTime();
+
+      if (millisecDiff < 30 * 1000) {
+        throw new HttpException(`${millisecDiff}`, HttpStatus.BAD_REQUEST);
+      }
     }
 
     party.otherMessageUsedDate = current;

--- a/src/user/user.entity.ts
+++ b/src/user/user.entity.ts
@@ -22,6 +22,9 @@ export class User {
   @Column({ type: 'int', default: 0 })
   point: number;
 
+  @Column({ type: 'varchar' })
+  fcmToken: string;
+
   @OneToOne(() => Party, (party) => party.host)
   party: Party;
 


### PR DESCRIPTION
## 유저 데이터를 가져올 수 있는 데코레이터 `UserDeco` 추가
`Request`를 가져와서, 거기서 유저 데이터를 가져오던 것을 데코레이터를 통해 해당 로직을 숨길 수 있습니다.

## 모집 완료된 후에만 접근할 수 있게 하는 `AfterCompleteGuard` 추가
컨트롤러의 각 필요한 메서드에 붙이면 작동합니다.
이를 통해 중복되는 코드들을 숨길 수 있습니다.

## 주최자만 접근할 수 있게 하는 `OnlyHostGuard` 추가
마찬가지로 컨트롤러의 각 필요한 메서드에 붙이면 작동합니다.

## 참가자들(주최자 포함)만 접근할 수 있게 하는 `OnlyParticipantGuard` 추가
마찬가지로 컨트롤러의 각 필요한 메서드에 붙이면 작동합니다.

## `PartyController` 내에서 "같이 먹을래?"의 아이디를 가르키는 파라미터의 이름 변경
해당 항목을 가르키던 `:id`가 위 추가된 가드들에서의 구분을 위해 `:partyId`로 변경되었습니다.

## 푸시 알림을 보낼 수 있는 기능 추가
':partyId/message/:msgType', PUT
아이디가 `partyId`인 "같이 먹을래?"에 발송자를 제외한 모든 참가자에게 `msgType`에 맞는 메세지를 보냅니다.

`msgType`은 다음의 값을 가질 수 있습니다.
'ordered-food', 'deliverer-picked-up', 'come-out'

만약 주최자가 아닌 참가자가 'ordered-food', 'deliverer-picked-up' 두 메세지를 보내려 시도할 경우 상태 코드 403(FORBIDDEN)을 보냅니다.
만약 주최자가 이미 'ordered-food', 'deliverer-picked-up' 메세지를 사용하였는데 또 사용하려 시도하거나, 참가자가 30초가 지나지 않았을 때 메세지를 보내려 시도한다면 400(BAD_REQUEST)를 보냅니다.

## `Party` 엔티티에 메세지 중복 전송 방지를 위한 열 추가
#22 에 작성된 규칙에 따르도록 해당 데이터를 저장할 필요성이 생겼습니다. 따라서 세 가지의 열을 추가하였으며, 아래와 같습니다.
'usedFirstMessage' (boolean) : 첫 번째 메세지('ordered-food')를 주최자가 사용하였는가?
'usedSecondMessage' (boolean) : 두 번째 메세지('deliverer-picked-up')를 주최자가 사용하였는가?
'otherMessageUsedDate' (Date) : 그 외의 메세지를 사용한 일시

## `User` 엔티티에 푸시 알림 전송을 위한 FCM 토큰을 가지는 열 추가
이 토큰을 통해 푸시 알림(메세지)을 전송합니다.